### PR TITLE
[v0.0.47] Update GitHub Actions workflows to use a consistent authent…

### DIFF
--- a/.github/workflows/test-develop.yml
+++ b/.github/workflows/test-develop.yml
@@ -14,7 +14,7 @@ jobs:
       VITE_EEN_CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
       VITE_EEN_CLIENT_SECRET: ${{ secrets.VITE_EEN_CLIENT_SECRET }}
       VITE_REDIRECT_URI: ${{ secrets.VITE_REDIRECT_URI }}
-      VITE_AUTH_PROXY_URL: http://127.0.0.1:3333
+      VITE_AUTH_PROXY_URL: https://een-login.klaushofrichter.workers.dev
       VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
       VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
       VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}

--- a/.github/workflows/test-gh-pages.yml
+++ b/.github/workflows/test-gh-pages.yml
@@ -66,7 +66,7 @@ jobs:
           VITE_EEN_CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
           VITE_EEN_CLIENT_SECRET: ${{ secrets.VITE_EEN_CLIENT_SECRET }}
           VITE_REDIRECT_URI: https://${{ github.repository_owner }}.github.io/${{ steps.extract_repo_name.outputs.LAST_PART }}
-          VITE_AUTH_PROXY_URL: ${{ steps.extract_repo_name.outputs.LAST_PART }}.klaushofrichter.workers.dev
+          VITE_AUTH_PROXY_URL: https://een-login.klaushofrichter.workers.dev
           TEST_USER: ${{ secrets.TEST_USER }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
           NODE_ENV: 'production' 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-capture",
-  "version": "0.0.46",
-  "lastCommit": "2025-05-25T16:10:16.863Z",
+  "version": "0.0.47",
+  "lastCommit": "2025-05-25T16:19:43.366Z",
   "private": true,
   "type": "module",
   "base": "/een-capture/",


### PR DESCRIPTION
…ication proxy URL

- Changed the VITE_AUTH_PROXY_URL in both test-develop.yml and test-gh-pages.yml to point to https://een-login.klaushofrichter.workers.dev, ensuring uniformity across environments.